### PR TITLE
Fixed the common errors by 'None' batch size and multiple uses

### DIFF
--- a/ops.py
+++ b/ops.py
@@ -18,18 +18,16 @@ def norm(x, norm_type, is_train, G=32, esp=1e-5):
             x = tf.transpose(x, [0, 3, 1, 2])
             N, C, H, W = x.get_shape().as_list()
             G = min(G, C)
-            x = tf.reshape(x, [N, G, C // G, H, W])
+            x = tf.reshape(x, [-1, G, C // G, H, W])
             mean, var = tf.nn.moments(x, [2, 3, 4], keep_dims=True)
             x = (x - mean) / tf.sqrt(var + esp)
             # per channel gamma and beta
-            gamma = tf.get_variable('gamma', [C],
-                                    initializer=tf.constant_initializer(1.0))
-            beta = tf.get_variable('beta', [C],
-                                   initializer=tf.constant_initializer(0.0))
+            gamma = tf.Variable(tf.constant(1.0, shape=[C]), dtype=tf.float32, name='gamma')
+            beta = tf.Variable(tf.constant(0.0, shape=[C]), dtype=tf.float32, name='beta')
             gamma = tf.reshape(gamma, [1, C, 1, 1])
             beta = tf.reshape(beta, [1, C, 1, 1])
 
-            output = tf.reshape(x, [N, C, H, W]) * gamma + beta
+            output = tf.reshape(x, [-1, C, H, W]) * gamma + beta
             # tranpose: [bs, c, h, w, c] to [bs, h, w, c] following the paper
             output = tf.transpose(output, [0, 2, 3, 1])
         else:


### PR DESCRIPTION
The errors by the following reported issues are fixed in this change.
- The undetermined batch size raises the list type error in Tensorflow.
- When the group normalization is used in several layers, the variable name confliction error raises due to the usage of get_variable().